### PR TITLE
Support IE 11

### DIFF
--- a/lib/control/iconselect.js
+++ b/lib/control/iconselect.js
@@ -113,7 +113,8 @@ function IconSelect($$elementID, $$parameters) {
             if(_selectedIndex != -1) _icons[_selectedIndex].element.setAttribute('class','icon selected');
         }
         
-        _View.iconSelectElement.dispatchEvent(new Event('changed'));
+        //_View.iconSelectElement.dispatchEvent(new Event('changed'));
+		_View.iconSelectElement.dispatchEvent(new CustomEvent('changed'));
         
         //_View.showBox(false);
         
@@ -316,3 +317,18 @@ function IconSelect($$elementID, $$parameters) {
     _init();
     
 }
+
+(function () {
+    if (typeof window.CustomEvent === "function") return false; //If not IE
+
+    function CustomEvent(event, params) {
+        params = params || { bubbles: false, cancelable: false, detail: undefined };
+        var evt = document.createEvent('CustomEvent');
+        evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
+        return evt;
+    }
+
+    CustomEvent.prototype = window.Event.prototype;
+
+    window.CustomEvent = CustomEvent;
+})();


### PR DESCRIPTION
I also encountered this problem in IE11.
After testing, error is "new Event('changed')"

Apply this method function can solve this problem.
Ref URL:
Https://stackoverflow.com/questions/26596123/internet-explorer-9-10-11-event-constructor-doesnt-work

(function () {
   If ( typeof window.CustomEvent === "function" ) return false; //If not IE

   Function CustomEvent ( event, params ) {
     Params = params || { bubbles: false, cancelable: false, detail: undefined };
     Var evt = document.createEvent( 'CustomEvent' );
     evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
     Return evt;
    }

   CustomEvent.prototype = window.Event.prototype;

   window.CustomEvent = CustomEvent;
})();
And this line(iconselect.js : line 116):
_View.iconSelectElement.dispatchEvent(new Event('changed'));

Change to:
_View.iconSelectElement.dispatchEvent(new CustomEvent('changed'));